### PR TITLE
Neuron monitor and podmonitor to detect it

### DIFF
--- a/charts/neuron-helm-chart/README.md
+++ b/charts/neuron-helm-chart/README.md
@@ -67,7 +67,7 @@ helm upgrade --install neuron-helm-chart oci://public.ecr.aws/neuron/neuron-helm
 ```
 
 ### Neuron Monitor and Prometheus PodMonitor
-The Neuron Monitor is not enabled by default.
+The Neuron Monitor is enabled by default.
 
 Configure `prometheusPodMonitor.prometheusSelectorLabels` in `Values.yaml` based on labels needed for your prometheus operator to detect PodMonitor.
 To install the Neuron Node Problem Detector Plugin:

--- a/charts/neuron-helm-chart/README.md
+++ b/charts/neuron-helm-chart/README.md
@@ -66,6 +66,16 @@ helm upgrade --install neuron-helm-chart oci://public.ecr.aws/neuron/neuron-helm
   --set "npd.nodeRecovery.enabled=true"
 ```
 
+### Neuron Monitor and Prometheus PodMonitor
+The Neuron Monitor is not enabled by default.
+
+Configure `prometheusPodMonitor.prometheusSelectorLabels` in `Values.yaml` based on labels needed for your prometheus operator to detect PodMonitor.
+To install the Neuron Node Problem Detector Plugin:
+```
+helm upgrade --install neuron-helm-chart oci://public.ecr.aws/neuron/neuron-helm-chart \
+  --set "monitor.enabled=true"
+```
+
 ## Uninstalling the Chart
 
 ```

--- a/charts/neuron-helm-chart/templates/_helpers.tpl
+++ b/charts/neuron-helm-chart/templates/_helpers.tpl
@@ -429,3 +429,116 @@ privileged: true
   {{- end }}
 {{- end }}
 {{- end -}}
+
+
+
+
+
+{{/*
+Templates for monitor.
+*/}}
+
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "monitor.name" -}}
+{{- default .Chart.Name .Values.monitor.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+Name for Neuron Monitor.
+*/}}
+{{- define "monitor.fullname" -}}
+{{- if .Values.monitor.fullnameOverride -}}
+{{- .Values.monitor.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.monitor.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Expand the namespace of the chart.
+*/}}
+{{- define "monitor.namespace" -}}
+{{- default .Release.Namespace .Values.monitor.namespaceOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels for Neuron Monitor
+*/}}
+{{- define "monitor.labels" -}}
+helm.sh/chart: {{ include "neuron-helm-chart.chart" . }}
+{{ include "monitor.exporter.templateLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Template labels for Neuron Monitor
+*/}}
+{{- define "monitor.exporter.templateLabels" -}}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Values.monitor.selectorLabelsOverride }}
+{{ toYaml .Values.monitor.selectorLabelsOverride }}
+{{- end }}
+{{- end }}
+
+{{/*
+Selector labels for Neuron Monitor
+*/}}
+{{- define "monitor.exporter.selectorLabels" -}}
+{{- if .Values.monitor.exporter.selectorLabelsOverride -}}
+{{ toYaml .Values.monitor.exporter.selectorLabelsOverride }}
+{{- else -}}
+app.kubernetes.io/name: {{ include "monitor.name" . }}-exporter
+{{ include "monitor.exporter.templateLabels" . }}
+{{- end }}
+{{- end }}
+
+{{/*
+Affinity for Neuron Monitor daemonset.
+*/}}
+{{- define "monitor.exporter.affinity" -}}
+{{- $instanceTypeKey := (include "node.instanceTypeKey" .) -}}
+{{- $neuronInstances := $.Values.neuronInstances | toYaml | nindent 8 -}}
+{{- $affinityYaml := .Values.monitor.exporter.affinity | toYaml | 
+     replace "__INSTANCE_TYPE_KEY__" $instanceTypeKey | 
+     replace "__NEURON_INSTANCES__" $neuronInstances -}}
+{{- tpl $affinityYaml $ -}}
+{{- end -}}
+
+{{- define "monitor.exporter.podAnnotations" -}}
+{{- if .Values.devicePlugin.podAnnotations }}
+  {{- range $key, $value := .Values.devicePlugin.podAnnotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+{{- end }}
+{{- if semverCompare "<=1.13-0" .Capabilities.KubeVersion.Version -}}
+scheduler.alpha.kubernetes.io/critical-pod: ""
+{{- end -}}
+{{- end -}}
+
+{{/*
+Neuron monitor image to use
+*/}}
+{{- define "monitor.exporter.fullimage" -}}
+{{- printf "%s:%s" .Values.monitor.exporter.image.repository (.Values.monitor.exporter.image.tag | default "{{ .Chart.AppVersion }}") -}}
+{{- end -}}
+
+
+{{/*
+Neuron monitor port name
+*/}}
+{{- define "monitor.exporter.portName" -}}
+"neuron-monitor"
+{{- end -}}

--- a/charts/neuron-helm-chart/templates/monitor-exporter-daemonset.yaml
+++ b/charts/neuron-helm-chart/templates/monitor-exporter-daemonset.yaml
@@ -1,0 +1,70 @@
+{{- if .Values.monitor.enabled }}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "monitor.fullname" . }}
+  namespace: {{ include "monitor.namespace" .  }}
+  labels:
+    {{- include "monitor.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "monitor.exporter.selectorLabels" . | nindent 6 }}
+  {{- with .Values.monitor.exporter.updateStrategy }}
+  updateStrategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  template:
+    metadata:
+      {{- with .Values.monitor.exporter.podAnnotations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "monitor.exporter.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.monitor.exporter.affinity }}
+      affinity:
+        {{- include "monitor.exporter.affinity" $ | nindent 8 }}
+      {{- end }}
+      {{- with .Values.monitor.exporter.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.monitor.exporter.priorityClassName }}
+      priorityClassName: {{ .Values.monitor.exporter.priorityClassName }}
+      {{- end }}
+      {{- if .Values.monitor.exporter.runtimeClassName }}
+      runtimeClassName: {{ .Values.monitor.exporter.runtimeClassName }}
+      {{- end }}
+      {{- with .Values.monitor.exporter.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.monitor.exporter.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.monitor.exporter.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: neuron-monitor
+          image: {{ include "monitor.exporter.fullimage" . }}
+          imagePullPolicy: {{ .Values.monitor.exporter.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.monitor.exporter.port }}
+              name: {{ include "monitor.exporter.portName" . }}
+          command:
+             - "/opt/bin/entrypoint.sh"
+          args: 
+            - "--port"
+            - "{{ .Values.monitor.exporter.port }}"  
+          resources:
+            {{- toYaml .Values.monitor.exporter.resources | nindent 12 }}
+          env:
+            {{- toYaml .Values.monitor.exporter.env | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.monitor.exporter.securityContext | nindent 12 }}
+{{- end }}

--- a/charts/neuron-helm-chart/templates/monitor-prometheus-podmonitor.yaml
+++ b/charts/neuron-helm-chart/templates/monitor-prometheus-podmonitor.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.monitor.prometheusPodMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: neuron-monitor
+  name: {{ include "monitor.fullname" . }}
+  namespace: {{ include "monitor.namespace" .  }}
+  labels:
+    {{- include "monitor.labels" . | nindent 4 }}
+    {{- if .Values.monitor.prometheusPodMonitor.prometheusSelectorLabels }}
+    {{- toYaml .Values.monitor.prometheusPodMonitor.prometheusSelectorLabels | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "monitor.exporter.selectorLabels" . | nindent 6 }}
+  podMetricsEndpoints:
+  - port: {{ include "monitor.exporter.portName" . }}
+    {{- if .Values.monitor.prometheusPodMonitor.neuronEndpointConfig }}
+    {{- toYaml .Values.monitor.prometheusPodMonitor.neuronEndpointConfig | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/charts/neuron-helm-chart/templates/monitor-prometheus-podmonitor.yaml
+++ b/charts/neuron-helm-chart/templates/monitor-prometheus-podmonitor.yaml
@@ -2,7 +2,6 @@
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
-  name: neuron-monitor
   name: {{ include "monitor.fullname" . }}
   namespace: {{ include "monitor.namespace" .  }}
   labels:

--- a/charts/neuron-helm-chart/values.yaml
+++ b/charts/neuron-helm-chart/values.yaml
@@ -200,3 +200,58 @@ npd:
       requests:
         cpu: 10m
         memory: 150Mi
+
+
+monitor:
+  enabled: true
+  # nameOverride: ""
+  # namespaceOverride: ""
+  fullnameOverride: neuron-monitor
+  exporter:
+    port: 8000
+    selectorLabelsOverride: {}
+    # priorityClassName: ""
+    # runtimeClassName: ""
+    imagePullSecrets: []
+    image:
+      repository: public.ecr.aws/neuron/neuron-monitor
+      pullPolicy: IfNotPresent
+      tag: "1.1.0"
+    resources:
+      limits:
+        cpu: 500m
+        memory: 256Mi
+      requests:
+        cpu: 256m
+        memory: 128Mi
+    podSecurityContext: {}
+    updateStrategy:
+      type: RollingUpdate
+    podAnnotations: {}
+    securityContext:
+      privileged: true
+    nodeSelector: {} # monitor is matched with affinity
+    tolerations:
+    - key: CriticalAddonsOnly
+      operator: Exists
+    - key: aws.amazon.com/neuron
+      operator: Exists
+      effect: NoSchedule
+    env:
+    - name: GOMEMLIMIT
+      value: 160MiB
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: "__INSTANCE_TYPE_KEY__"
+                  operator: In
+                  values: "__NEURON_INSTANCES__"
+  prometheusPodMonitor:
+    enabled: true
+    prometheusSelectorLabels:
+      release: kube-prometheus-stack
+      jobLabel: neuron-monitor
+    neuronEndpointConfig:
+      interval: "10s"


### PR DESCRIPTION
*Description of changes:*
This PR adds Neuron monitor to the chart. I intend to add other storage backends like CloudWatch and Amazon managed Prometheus, for now only adding in-cluster Prometheus support via PodMonitor.
