### PR TITLE
Release Helm Chart v1.3.1 for Neuron SDK 2.26.1 patch release

### DIFF
--- a/charts/neuron-helm-chart/Chart.yaml
+++ b/charts/neuron-helm-chart/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.0
+version: 1.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.3.0"
+appVersion: "1.3.1"

--- a/charts/neuron-helm-chart/values.yaml
+++ b/charts/neuron-helm-chart/values.yaml
@@ -12,7 +12,7 @@ devicePlugin:
     repository: public.ecr.aws/neuron/neuron-device-plugin
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "2.28.4.0"
+    tag: "2.28.27.0"
   podSecurityContext: {}
   serviceAccount:
     # Specifies whether a service account should be created
@@ -82,7 +82,7 @@ scheduler:
   image:
     repository: public.ecr.aws/neuron/neuron-scheduler
     pullPolicy: IfNotPresent
-    tag: "2.28.4.0"
+    tag: "2.28.27.0"
   imagePullSecrets: []
   nameOverride: neuron-scheduler
   namespaceOverride: kube-system


### PR DESCRIPTION
*Issue #, if available:* Neuron containers team released scheduler and device plugin images with updated Golang version 1.25.3 to patch high security findings.
- https://gallery.ecr.aws/neuron/neuron-device-plugin
- https://gallery.ecr.aws/neuron/neuron-scheduler


Helm chart version patch to reference new image versions.

*Description of changes:* 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
